### PR TITLE
Исправлен учёт администратора в рассылках

### DIFF
--- a/PomogatorBot.Web/Commands/BroadcastCommandHandler.cs
+++ b/PomogatorBot.Web/Commands/BroadcastCommandHandler.cs
@@ -62,6 +62,7 @@ public class BroadcastCommandHandler(
             subscribes,
             entities,
             () => keyboardFactory.CreateForBroadcastConfirmation(string.Empty),
+            message.From!.Id,
             cancellationToken);
 
         var pendingId = broadcastPendingService.Store(broadcastMessage, subscribes, entities, message.From!.Id);

--- a/PomogatorBot.Web/Common/Workflows/BroadcastWorkflow.cs
+++ b/PomogatorBot.Web/Common/Workflows/BroadcastWorkflow.cs
@@ -27,6 +27,7 @@ public static class BroadcastWorkflow
                         subscribes,
                         entities,
                         () => keyboardFactory.CreateForBroadcastConfirmation(string.Empty),
+                        adminUserId,
                         cancellationToken);
 
                     var pendingId = broadcastPendingService.Store(message, subscribes, entities, adminUserId);

--- a/PomogatorBot.Web/Services/BroadcastExecutionService.cs
+++ b/PomogatorBot.Web/Services/BroadcastExecutionService.cs
@@ -1,4 +1,4 @@
-using System.Threading.Channels;
+﻿using System.Threading.Channels;
 
 namespace PomogatorBot.Web.Services;
 
@@ -88,7 +88,7 @@ public class BroadcastExecutionService : BackgroundService
 
         try
         {
-            var userCount = await userService.GetCountBySubscriptionAsync(broadcastTask.Subscribes, cancellationToken);
+            var userCount = await userService.GetCountBySubscriptionAsync(broadcastTask.Subscribes, broadcastTask.AdminUserId, cancellationToken);
 
             broadcastProgressService.StartProgress(broadcastTask.BroadcastId,
                 broadcastTask.ChatId,

--- a/PomogatorBot.Web/Services/BroadcastPreviewService.cs
+++ b/PomogatorBot.Web/Services/BroadcastPreviewService.cs
@@ -12,9 +12,10 @@ public sealed class BroadcastPreviewService(
         Subscribes subscribes,
         MessageEntity[]? entities,
         Func<InlineKeyboardMarkup> keyboardFactory,
-        CancellationToken cancellationToken)
+        long? adminId = null,
+        CancellationToken cancellationToken = default)
     {
-        var userCount = await userService.GetCountBySubscriptionAsync(subscribes, cancellationToken);
+        var userCount = await userService.GetCountBySubscriptionAsync(subscribes, adminId, cancellationToken);
         var subscriptionInfo = GetSubscriptionDisplayInfo(subscribes);
         var preview = messagePreviewService.CreatePreview(message, entities);
 
@@ -22,7 +23,7 @@ public sealed class BroadcastPreviewService(
                              {Emoji.Megaphone} Подтверждение рассылки:
 
                              {Emoji.Target} Подписки: {subscriptionInfo}
-                             {Emoji.Users} Получателей (админ учитывается): {userCount}
+                             {Emoji.Users} Получателей: {userCount}
 
                              {Emoji.List} Предварительный просмотр (как увидят пользователи):
                              ━━━━━

--- a/PomogatorBot.Web/Services/UserService.cs
+++ b/PomogatorBot.Web/Services/UserService.cs
@@ -1,4 +1,4 @@
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using PomogatorBot.Web.Infrastructure;
 using PomogatorBot.Web.Infrastructure.Entities;
 using Telegram.Bot;
@@ -79,11 +79,17 @@ public class UserService(
         return true;
     }
 
-    public async Task<int> GetCountBySubscriptionAsync(Subscribes subscribes, CancellationToken cancellationToken = default)
+    public Task<int> GetCountBySubscriptionAsync(Subscribes subscribes, long? excludeUserId = null, CancellationToken cancellationToken = default)
     {
-        return await context.Users
-            .Where(x => (x.Subscriptions & subscribes) == subscribes)
-            .CountAsync(cancellationToken);
+        var queryable = context.Users
+            .Where(x => (x.Subscriptions & subscribes) == subscribes);
+
+        if (excludeUserId.HasValue)
+        {
+            queryable = queryable.Where(x => x.UserId != excludeUserId.Value);
+        }
+
+        return queryable.CountAsync(cancellationToken);
     }
 
     public Task<NotifyResponse> NotifyAsync(


### PR DESCRIPTION
Исправлен учёт администратора в рассылках
- В UserService добавлен параметр для исключения ID администратора при подсчёте получателей
- В предпросмотре рассылки теперь отображается реальное количество пользователей без учёта админа
- Из текста подтверждения удалено сбивающее с толку примечание «админ учитывается»
- Прогресс выполнения и история рассылок теперь используют корректное число участников
- Обеспечена передача ID администратора из команд и воркфлоу для точного расчёта